### PR TITLE
Fixed issues on code highlight mid-comment.

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -116,22 +116,19 @@ class Editor(tk.Frame):
         self.event_generate("<<Compare>>")
         self.highlight()
         
-    def highlight_line(self, event=None, line=None):
+    def highlight_line(self, line=None):
+        start_range = 0
         index = self.text.index("insert").split(".")
-        line_no = int(index[0])
         
         if line == None:
-            line_text = self.text.get("{}.{}".format(line_no, 0),  "{}.end".format(line_no))
-            self.text.mark_set("range_start", str(line_no) + '.0')
+            line = int(index[0])
         
-        elif line is not None:
-            line_text = self.text.get("{}.{}".format(line, 0), "{}.end".format(line))
-            self.text.mark_set("range_start", str(line) + '.0')
+        line_text = self.text.get("{}.{}".format(line, 0), "{}.end".format(line))
 
         for token, content in lex(line_text, BrainfuckLexer()):
-            self.text.mark_set("range_end", "range_start + %dc" % len(content))
-            self.text.tag_add(str(token), "range_start", "range_end")
-            self.text.mark_set("range_start", "range_end")
+            end_range = start_range + len(content)
+            self.text.tag_add(str(token), '{}.{}'.format(line,start_range), '{}.{}'.format(line,end_range))
+            start_range = end_range
 
 
     def highlight(self, *args):


### PR DESCRIPTION
## What changes:
- Removed the unused "event" argument for the `higlight_line` function.
- Removed all the mark_sets, now basing the tag_add in the start_range variable.
- Changed the if/elif line to more readable code, just applying one if to reassign the line variable if it is None. This allow the removal of line_no variable.

## Why these changes?
Previously the IDE would not highlight brainfuck commands in comments and would stop highlighting them in other parts randomly, making commands appear as plain text. In the current version of the IDE, `++--hello<>world` would not highlight the "<>"  between "hello" and "world". This has been fixed with the new approach to the highlighting. Of course, this basic example should not be enough to tell if this works or not, but I did some more testing and I believe it solves most problems in highlighting.